### PR TITLE
Não existe mais o campo pic na API 2.1

### DIFF
--- a/thrift/layout-ras/thrift/ficha_atendimento_individual.thrift
+++ b/thrift/layout-ras/thrift/ficha_atendimento_individual.thrift
@@ -40,7 +40,7 @@ struct FichaAtendimentoIndividualChildThrift {
 	16:optional list<string> examesAvaliados;
 	17:optional list<OutrosSiaThrift> outrosSia;
 	18:optional bool vacinaEmDia;
-	19:optional i64 pic;
+	19:optional i64 racionalidadeSaude;
 	20:optional bool ficouEmObservacao;
 	21:optional list<i64> nasfs;
 	22:optional list<i64> condutas;


### PR DESCRIPTION
Conforme consta no manual de integração da API versão 2.1.0 (http://esusab.github.io/integracao/v210/docs/dicionario-fai.html) o campo pic deixou de existir. Pelo que pude perceber o campo racionalidadeSaude acabou substituindo o campo pic parcialmente, no que se refere aos valores permitidos para o campo.